### PR TITLE
Fix a few deadlocks which caused by mutex lock leaking

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -82,11 +82,18 @@ var netMap = map[string]string{
 
 // Read reads data from the connection.
 func (c *Conn) Read(b []byte) (n int, err error) {
-	c.mu.Lock()
-	if c.state != StateAspActive {
-		return 0, ErrNotEstablished
+	err = func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		if c.state != StateAspActive {
+			return ErrNotEstablished
+		}
+		return nil
+	}()
+	if err != nil {
+		return 0, err
 	}
-	c.mu.Unlock()
 
 	pd, ok := <-c.dataChan
 	if !ok {


### PR DESCRIPTION
If the current handler returns the error early, the mutex lock won't be free. This commit fixes such deadlock issue.