### PR TITLE
Add setter-based config manipulation

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,29 +11,7 @@ import (
 	"time"
 
 	"github.com/ishidawataru/sctp"
-	"github.com/wmnsk/go-m3ua/messages/params"
 )
-
-// NewClientConfig creates a new Config for Client.
-//
-// The optional parameters that is not required (like CorrelationID),
-// omit it by setting it to nil after created *Config.
-func NewClientConfig(hbInfo *HeartbeatInfo, opc, dpc, aspID, tmt, nwApr, corrID uint32, rtCtxs []uint32, si, ni, mp, sls uint8) *Config {
-	return &Config{
-		HeartbeatInfo:          hbInfo,
-		AspIdentifier:          params.NewAspIdentifier(aspID),
-		TrafficModeType:        params.NewTrafficModeType(tmt),
-		NetworkAppearance:      params.NewNetworkAppearance(nwApr),
-		RoutingContexts:        params.NewRoutingContext(rtCtxs...),
-		CorrelationID:          params.NewCorrelationID(corrID),
-		OriginatingPointCode:   opc,
-		DestinationPointCode:   dpc,
-		ServiceIndicator:       si,
-		NetworkIndicator:       ni,
-		MessagePriority:        mp,
-		SignalingLinkSelection: sls,
-	}
-}
 
 // Dial establishes a M3UA connection as a client.
 //

--- a/config.go
+++ b/config.go
@@ -1,0 +1,145 @@
+// Copyright 2018-2019 go-m3ua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package m3ua
+
+import (
+	"time"
+
+	"github.com/wmnsk/go-m3ua/messages/params"
+)
+
+// HeartbeatInfo is a set of information for M3UA BEAT.
+type HeartbeatInfo struct {
+	Enabled  bool
+	Interval time.Duration
+	Timer    time.Duration
+	Data     []byte
+}
+
+// NewHeartbeatInfo creates a new HeartbeatInfo.
+func NewHeartbeatInfo(interval, timer time.Duration, data []byte) *HeartbeatInfo {
+	return &HeartbeatInfo{
+		Enabled: true, Interval: interval, Timer: timer, Data: data,
+	}
+}
+
+// Config is a configration that defines a M3UA server.
+type Config struct {
+	*HeartbeatInfo
+	AspIdentifier          *params.Param
+	TrafficModeType        *params.Param
+	NetworkAppearance      *params.Param
+	RoutingContexts        *params.Param
+	CorrelationID          *params.Param
+	OriginatingPointCode   uint32
+	DestinationPointCode   uint32
+	ServiceIndicator       uint8
+	NetworkIndicator       uint8
+	MessagePriority        uint8
+	SignalingLinkSelection uint8
+}
+
+// NewConfig creates a new Config.
+//
+// To set additional parameters, use constructors in param package or
+// setters defined in this package. Note that the params left nil won't
+// appear in the packets but the initialized params will, with zero
+// values.
+func NewConfig(opc, dpc uint32, si, ni, mp, sls uint8) *Config {
+	return &Config{
+		OriginatingPointCode:   opc,
+		DestinationPointCode:   dpc,
+		ServiceIndicator:       si,
+		NetworkIndicator:       ni,
+		MessagePriority:        mp,
+		SignalingLinkSelection: sls,
+	}
+}
+
+// EnableHeartbeat enables M3UA BEAT with interval and expiration timer
+// given.
+//
+// The data is hard-coded by default. Manipulate the exported field
+// Config.HeartbeatInfo.Data to customize it such as including current
+// time to identify the BEAT and BEAT ACK pair.
+func (c *Config) EnableHeartbeat(interval, timer time.Duration) *Config {
+	c.HeartbeatInfo = NewHeartbeatInfo(
+		interval, timer,
+		[]byte("Hi, this is a BEAT from go-m3ua. Are you alive?"),
+	)
+	return c
+}
+
+// SetAspIdentifier sets AspIdentifier in Config.
+func (c *Config) SetAspIdentifier(id uint32) *Config {
+	c.AspIdentifier = params.NewAspIdentifier(id)
+	return c
+}
+
+// SetTrafficModeType sets TrafficModeType in Config.
+func (c *Config) SetTrafficModeType(tmType uint32) *Config {
+	c.TrafficModeType = params.NewTrafficModeType(tmType)
+	return c
+}
+
+// SetNetworkAppearance sets NetworkAppearance in Config.
+func (c *Config) SetNetworkAppearance(nwApr uint32) *Config {
+	c.NetworkAppearance = params.NewNetworkAppearance(nwApr)
+	return c
+}
+
+// SetRoutingContexts sets RoutingContexts in Config.
+func (c *Config) SetRoutingContexts(rtCtxs ...uint32) *Config {
+	c.RoutingContexts = params.NewRoutingContext(rtCtxs...)
+	return c
+}
+
+// SetCorrelationID sets CorrelationID in Config.
+func (c *Config) SetCorrelationID(id uint32) *Config {
+	c.CorrelationID = params.NewCorrelationID(id)
+	return c
+}
+
+// NewClientConfig creates a new Config for Client.
+//
+// The optional parameters that is not required (like CorrelationID)
+// can be omitted by setting it to nil after created *Config.
+func NewClientConfig(hbInfo *HeartbeatInfo, opc, dpc, aspID, tmt, nwApr, corrID uint32, rtCtxs []uint32, si, ni, mp, sls uint8) *Config {
+	return &Config{
+		HeartbeatInfo:          hbInfo,
+		AspIdentifier:          params.NewAspIdentifier(aspID),
+		TrafficModeType:        params.NewTrafficModeType(tmt),
+		NetworkAppearance:      params.NewNetworkAppearance(nwApr),
+		RoutingContexts:        params.NewRoutingContext(rtCtxs...),
+		CorrelationID:          params.NewCorrelationID(corrID),
+		OriginatingPointCode:   opc,
+		DestinationPointCode:   dpc,
+		ServiceIndicator:       si,
+		NetworkIndicator:       ni,
+		MessagePriority:        mp,
+		SignalingLinkSelection: sls,
+	}
+}
+
+// NewServerConfig creates a new Config for Server.
+//
+// The optional parameters that is not required (like CorrelationID)
+// can be omitted by setting it to nil after created *Config.
+func NewServerConfig(hbInfo *HeartbeatInfo, opc, dpc, aspID, tmt, nwApr, corrID uint32, rtCtxs []uint32, si, ni, mp, sls uint8) *Config {
+	return &Config{
+		HeartbeatInfo:          hbInfo,
+		AspIdentifier:          params.NewAspIdentifier(aspID),
+		TrafficModeType:        params.NewTrafficModeType(tmt),
+		NetworkAppearance:      params.NewNetworkAppearance(nwApr),
+		RoutingContexts:        params.NewRoutingContext(rtCtxs...),
+		CorrelationID:          params.NewCorrelationID(corrID),
+		OriginatingPointCode:   opc,
+		DestinationPointCode:   dpc,
+		ServiceIndicator:       si,
+		NetworkIndicator:       ni,
+		MessagePriority:        mp,
+		SignalingLinkSelection: sls,
+	}
+}

--- a/conn.go
+++ b/conn.go
@@ -17,30 +17,6 @@ import (
 	"github.com/wmnsk/go-m3ua/messages/params"
 )
 
-// HeartbeatInfo is a set of information for M3UA BEAT.
-type HeartbeatInfo struct {
-	Enabled  bool
-	Interval time.Duration
-	Timer    time.Duration
-	Data     []byte
-}
-
-// Config is a configration that defines a M3UA server.
-type Config struct {
-	*HeartbeatInfo
-	AspIdentifier          *params.Param
-	TrafficModeType        *params.Param
-	NetworkAppearance      *params.Param
-	RoutingContexts        *params.Param
-	CorrelationID          *params.Param
-	OriginatingPointCode   uint32
-	DestinationPointCode   uint32
-	ServiceIndicator       uint8
-	NetworkIndicator       uint8
-	MessagePriority        uint8
-	SignalingLinkSelection uint8
-}
-
 type mode uint8
 
 const (

--- a/examples/client/m3ua-client.go
+++ b/examples/client/m3ua-client.go
@@ -35,6 +35,22 @@ func main() {
 	}
 
 	// create *Config to be used in M3UA connection
+	config := m3ua.NewConfig(
+		0x11111111,            // OriginatingPointCode
+		0x22222222,            // DestinationPointCode
+		params.ServiceIndSCCP, // ServiceIndicator
+		0,                     // NetworkIndicator
+		0,                     // MessagePriority
+		1,                     // SignalingLinkSelection
+	)
+	config. // set parameters to use
+		EnableHeartbeat(*hbInt, 10*time.Second).
+		SetAspIdentifier(1).
+		SetTrafficModeType(params.TrafficModeLoadshare).
+		SetNetworkAppearance(0).
+		SetRoutingContexts(1, 2)
+
+	/* or, you can define config in the following way.
 	config := m3ua.NewClientConfig(
 		&m3ua.HeartbeatInfo{
 			Enabled:  true,
@@ -55,6 +71,7 @@ func main() {
 	)
 	// set nil on unnecessary parameters.
 	config.CorrelationID = nil
+	*/
 
 	// setup SCTP peer on the specified IPs and Port.
 	raddr, err := sctp.ResolveSCTPAddr("sctp", *addr)

--- a/server.go
+++ b/server.go
@@ -14,26 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ishidawataru/sctp"
-	"github.com/wmnsk/go-m3ua/messages/params"
 )
-
-// NewServerConfig creates a new Config for Server.
-func NewServerConfig(hbInfo *HeartbeatInfo, opc, dpc, aspID, tmt, nwApr, corrID uint32, rtCtxs []uint32, si, ni, mp, sls uint8) *Config {
-	return &Config{
-		HeartbeatInfo:          hbInfo,
-		AspIdentifier:          params.NewAspIdentifier(aspID),
-		TrafficModeType:        params.NewTrafficModeType(tmt),
-		NetworkAppearance:      params.NewNetworkAppearance(nwApr),
-		RoutingContexts:        params.NewRoutingContext(rtCtxs...),
-		CorrelationID:          params.NewCorrelationID(corrID),
-		OriginatingPointCode:   opc,
-		DestinationPointCode:   dpc,
-		ServiceIndicator:       si,
-		NetworkIndicator:       ni,
-		MessagePriority:        mp,
-		SignalingLinkSelection: sls,
-	}
-}
 
 // Listener is a M3UA listener.
 type Listener struct {


### PR DESCRIPTION
Added some setters to set parameters without using `params.NewXXX` constructors. Unlike the previously-used `NewClient/ServerConfig`, we no longer need to set `nil` explicitly for unused parameters.

The functional options may also be good for painless handling of Config. I'll try it another time as it requires a bit more effort.
https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
