### PR TITLE
Replace names of encoding/decoding funcs

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -92,7 +92,7 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 			c.cfg.ServiceIndicator, c.cfg.NetworkIndicator,
 			c.cfg.MessagePriority, c.cfg.SignalingLinkSelection, b,
 		), c.cfg.CorrelationID,
-	).Serialize()
+	).MarshalBinary()
 	if err != nil {
 		return 0, err
 	}
@@ -108,9 +108,9 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 
 // WriteSignal writes any type of M3UA signals on top of SCTP Connection.
 func (c *Conn) WriteSignal(m3 messages.M3UA) (n int, err error) {
-	n = m3.Len()
+	n = m3.MarshalLen()
 	buf := make([]byte, n)
-	if err := m3.SerializeTo(buf); err != nil {
+	if err := m3.MarshalTo(buf); err != nil {
 		return 0, fmt.Errorf("failed to create %T: %s", m3, err)
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -56,7 +56,7 @@ func (e *ErrUnsupportedClass) Error() string {
 }
 
 func (e *ErrUnsupportedClass) first40Octets() []byte {
-	b, err := e.Msg.Serialize()
+	b, err := e.Msg.MarshalBinary()
 	if err != nil {
 		return nil
 	}
@@ -84,7 +84,7 @@ func (e *ErrUnsupportedMessage) Error() string {
 }
 
 func (e *ErrUnsupportedMessage) first40Octets() []byte {
-	b, err := e.Msg.Serialize()
+	b, err := e.Msg.MarshalBinary()
 	if err != nil {
 		return nil
 	}

--- a/fsm.go
+++ b/fsm.go
@@ -220,8 +220,8 @@ func (c *Conn) monitor(ctx context.Context) {
 				}
 			}
 
-			// Decode the received packet as M3UA. Undecodable packets are ignored.
-			msg, err := messages.Decode(buf[:n])
+			// Parse the received packet as M3UA. Undecodable packets are ignored.
+			msg, err := messages.Parse(buf[:n])
 			if err != nil {
 				continue
 			}

--- a/messages/asp-active-ack.go
+++ b/messages/asp-active-ack.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -37,65 +38,65 @@ func NewAspActiveAck(tmt, rtCtx, info *params.Param) *AspActiveAck {
 	return a
 }
 
-// Serialize returns the byte sequence generated from a AspActiveAck.
-func (a *AspActiveAck) Serialize() ([]byte, error) {
-	b := make([]byte, a.Len())
-	if err := a.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a AspActiveAck.
+func (a *AspActiveAck) MarshalBinary() ([]byte, error) {
+	b := make([]byte, a.MarshalLen())
+	if err := a.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize AspActiveAck")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (a *AspActiveAck) SerializeTo(b []byte) error {
-	if len(b) < a.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (a *AspActiveAck) MarshalTo(b []byte) error {
+	if len(b) < a.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	a.Header.Payload = make([]byte, a.Len()-8)
+	a.Header.Payload = make([]byte, a.MarshalLen()-8)
 
 	var offset = 0
-	if a.TrafficModeType != nil {
-		if err := a.TrafficModeType.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.TrafficModeType; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += a.TrafficModeType.Len()
+		offset += param.MarshalLen()
 	}
 
-	if a.RoutingContext != nil {
-		if err := a.RoutingContext.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.RoutingContext; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += a.RoutingContext.Len()
+		offset += param.MarshalLen()
 	}
 
-	if a.InfoString != nil {
-		if err := a.InfoString.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.InfoString; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
 
-	return a.Header.SerializeTo(b)
+	return a.Header.MarshalTo(b)
 }
 
-// DecodeAspActiveAck decodes given byte sequence as a AspActiveAck.
-func DecodeAspActiveAck(b []byte) (*AspActiveAck, error) {
+// ParseAspActiveAck decodes given byte sequence as a AspActiveAck.
+func ParseAspActiveAck(b []byte) (*AspActiveAck, error) {
 	a := &AspActiveAck{}
-	if err := a.DecodeFromBytes(b); err != nil {
+	if err := a.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (a *AspActiveAck) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (a *AspActiveAck) UnmarshalBinary(b []byte) error {
 	var err error
-	a.Header, err = DecodeHeader(b)
+	a.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(a.Header.Payload)
+	prs, err := params.ParseMultiParams(a.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -116,31 +117,31 @@ func (a *AspActiveAck) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (a *AspActiveAck) SetLength() {
-	if a.TrafficModeType != nil {
-		a.TrafficModeType.SetLength()
+	if param := a.TrafficModeType; param != nil {
+		param.SetLength()
 	}
-	if a.RoutingContext != nil {
-		a.RoutingContext.SetLength()
+	if param := a.RoutingContext; param != nil {
+		param.SetLength()
 	}
-	if a.InfoString != nil {
-		a.InfoString.SetLength()
+	if param := a.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	a.Header.SetLength()
-	a.Header.Length += uint32(a.Len())
+	a.Header.Length += uint32(a.MarshalLen())
 }
 
-// Len returns the actual length of AspActiveAck.
-func (a *AspActiveAck) Len() int {
+// MarshalLen returns the serial length of AspActiveAck.
+func (a *AspActiveAck) MarshalLen() int {
 	l := 8
-	if a.TrafficModeType != nil {
-		l += a.TrafficModeType.Len()
+	if param := a.TrafficModeType; param != nil {
+		l += param.MarshalLen()
 	}
-	if a.RoutingContext != nil {
-		l += a.RoutingContext.Len()
+	if param := a.RoutingContext; param != nil {
+		l += param.MarshalLen()
 	}
-	if a.InfoString != nil {
-		l += a.InfoString.Len()
+	if param := a.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -178,4 +179,44 @@ func (a *AspActiveAck) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (a *AspActiveAck) MessageTypeName() string {
 	return "ASP Active Ack"
+}
+
+// Serialize returns the byte sequence generated from a AspActiveAck.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (a *AspActiveAck) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return a.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (a *AspActiveAck) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return a.MarshalTo(b)
+}
+
+// DecodeAspActiveAck decodes given byte sequence as a AspActiveAck.
+//
+// DEPRECATED: use ParseAspActiveAck instead.
+func DecodeAspActiveAck(b []byte) (*AspActiveAck, error) {
+	log.Println("DEPRECATED: use ParseAspActiveAck instead")
+	return ParseAspActiveAck(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (a *AspActiveAck) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return a.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of AspActiveAck.
+//
+// DEPRECATED: use MarshalLen instead.
+func (a *AspActiveAck) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return a.MarshalLen()
 }

--- a/messages/asp-active-ack_test.go
+++ b/messages/asp-active-ack_test.go
@@ -130,7 +130,7 @@ func TestAspActiveAck(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeAspActiveAck(b)
+		v, err := ParseAspActiveAck(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/asp-active.go
+++ b/messages/asp-active.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -37,65 +38,65 @@ func NewAspActive(tmt, rtCtx, info *params.Param) *AspActive {
 	return a
 }
 
-// Serialize returns the byte sequence generated from a AspActive.
-func (a *AspActive) Serialize() ([]byte, error) {
-	b := make([]byte, a.Len())
-	if err := a.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a AspActive.
+func (a *AspActive) MarshalBinary() ([]byte, error) {
+	b := make([]byte, a.MarshalLen())
+	if err := a.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize AspActive")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (a *AspActive) SerializeTo(b []byte) error {
-	if len(b) < a.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (a *AspActive) MarshalTo(b []byte) error {
+	if len(b) < a.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	a.Header.Payload = make([]byte, a.Len()-8)
+	a.Header.Payload = make([]byte, a.MarshalLen()-8)
 
 	var offset = 0
-	if a.TrafficModeType != nil {
-		if err := a.TrafficModeType.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.TrafficModeType; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += a.TrafficModeType.Len()
+		offset += param.MarshalLen()
 	}
 
-	if a.RoutingContext != nil {
-		if err := a.RoutingContext.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.RoutingContext; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += a.RoutingContext.Len()
+		offset += param.MarshalLen()
 	}
 
-	if a.InfoString != nil {
-		if err := a.InfoString.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.InfoString; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
 
-	return a.Header.SerializeTo(b)
+	return a.Header.MarshalTo(b)
 }
 
-// DecodeAspActive decodes given byte sequence as a AspActive.
-func DecodeAspActive(b []byte) (*AspActive, error) {
+// ParseAspActive decodes given byte sequence as a AspActive.
+func ParseAspActive(b []byte) (*AspActive, error) {
 	a := &AspActive{}
-	if err := a.DecodeFromBytes(b); err != nil {
+	if err := a.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (a *AspActive) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (a *AspActive) UnmarshalBinary(b []byte) error {
 	var err error
-	a.Header, err = DecodeHeader(b)
+	a.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(a.Header.Payload)
+	prs, err := params.ParseMultiParams(a.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -116,31 +117,31 @@ func (a *AspActive) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (a *AspActive) SetLength() {
-	if a.TrafficModeType != nil {
-		a.TrafficModeType.SetLength()
+	if param := a.TrafficModeType; param != nil {
+		param.SetLength()
 	}
-	if a.RoutingContext != nil {
-		a.RoutingContext.SetLength()
+	if param := a.RoutingContext; param != nil {
+		param.SetLength()
 	}
-	if a.InfoString != nil {
-		a.InfoString.SetLength()
+	if param := a.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	a.Header.SetLength()
-	a.Header.Length += uint32(a.Len())
+	a.Header.Length += uint32(a.MarshalLen())
 }
 
-// Len returns the actual length of AspActive.
-func (a *AspActive) Len() int {
+// MarshalLen returns the serial length of AspActive.
+func (a *AspActive) MarshalLen() int {
 	l := 8
-	if a.TrafficModeType != nil {
-		l += a.TrafficModeType.Len()
+	if param := a.TrafficModeType; param != nil {
+		l += param.MarshalLen()
 	}
-	if a.RoutingContext != nil {
-		l += a.RoutingContext.Len()
+	if param := a.RoutingContext; param != nil {
+		l += param.MarshalLen()
 	}
-	if a.InfoString != nil {
-		l += a.InfoString.Len()
+	if param := a.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -178,4 +179,44 @@ func (a *AspActive) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (a *AspActive) MessageTypeName() string {
 	return "ASP Active"
+}
+
+// Serialize returns the byte sequence generated from a AspActive.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (a *AspActive) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return a.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (a *AspActive) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return a.MarshalTo(b)
+}
+
+// DecodeAspActive decodes given byte sequence as a AspActive.
+//
+// DEPRECATED: use ParseAspActive instead.
+func DecodeAspActive(b []byte) (*AspActive, error) {
+	log.Println("DEPRECATED: use ParseAspActive instead")
+	return ParseAspActive(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (a *AspActive) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return a.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of AspActive.
+//
+// DEPRECATED: use MarshalLen instead.
+func (a *AspActive) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return a.MarshalLen()
 }

--- a/messages/asp-active_test.go
+++ b/messages/asp-active_test.go
@@ -137,7 +137,7 @@ func TestAspActive(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeAspActive(b)
+		v, err := ParseAspActive(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/asp-down-ack.go
+++ b/messages/asp-down-ack.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -34,50 +35,50 @@ func NewAspDownAck(info *params.Param) *AspDownAck {
 	return a
 }
 
-// Serialize returns the byte sequence generated from a AspDownAck.
-func (a *AspDownAck) Serialize() ([]byte, error) {
-	b := make([]byte, a.Len())
-	if err := a.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a AspDownAck.
+func (a *AspDownAck) MarshalBinary() ([]byte, error) {
+	b := make([]byte, a.MarshalLen())
+	if err := a.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize AspDownAck")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (a *AspDownAck) SerializeTo(b []byte) error {
-	if len(b) < a.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (a *AspDownAck) MarshalTo(b []byte) error {
+	if len(b) < a.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	a.Header.Payload = make([]byte, a.Len()-8)
+	a.Header.Payload = make([]byte, a.MarshalLen()-8)
 
-	if a.InfoString != nil {
-		if err := a.InfoString.SerializeTo(a.Header.Payload); err != nil {
+	if param := a.InfoString; param != nil {
+		if err := param.MarshalTo(a.Header.Payload); err != nil {
 			return err
 		}
 	}
 
-	return a.Header.SerializeTo(b)
+	return a.Header.MarshalTo(b)
 }
 
-// DecodeAspDownAck decodes given byte sequence as a AspDownAck.
-func DecodeAspDownAck(b []byte) (*AspDownAck, error) {
+// ParseAspDownAck decodes given byte sequence as a AspDownAck.
+func ParseAspDownAck(b []byte) (*AspDownAck, error) {
 	a := &AspDownAck{}
-	if err := a.DecodeFromBytes(b); err != nil {
+	if err := a.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (a *AspDownAck) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (a *AspDownAck) UnmarshalBinary(b []byte) error {
 	var err error
-	a.Header, err = DecodeHeader(b)
+	a.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(a.Header.Payload)
+	prs, err := params.ParseMultiParams(a.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -94,19 +95,19 @@ func (a *AspDownAck) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (a *AspDownAck) SetLength() {
-	if a.InfoString != nil {
-		a.InfoString.SetLength()
+	if param := a.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	a.Header.SetLength()
-	a.Header.Length += uint32(a.Len())
+	a.Header.Length += uint32(a.MarshalLen())
 }
 
-// Len returns the actual length of AspDownAck.
-func (a *AspDownAck) Len() int {
+// MarshalLen returns the serial length of AspDownAck.
+func (a *AspDownAck) MarshalLen() int {
 	l := 8
-	if a.InfoString != nil {
-		l += a.InfoString.Len()
+	if param := a.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -142,4 +143,44 @@ func (a *AspDownAck) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (a *AspDownAck) MessageTypeName() string {
 	return "ASP Down Ack"
+}
+
+// Serialize returns the byte sequence generated from a AspDownAck.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (a *AspDownAck) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return a.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (a *AspDownAck) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return a.MarshalTo(b)
+}
+
+// DecodeAspDownAck decodes given byte sequence as a AspDownAck.
+//
+// DEPRECATED: use ParseAspDownAck instead.
+func DecodeAspDownAck(b []byte) (*AspDownAck, error) {
+	log.Println("DEPRECATED: use ParseAspDownAck instead")
+	return ParseAspDownAck(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (a *AspDownAck) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return a.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of AspDownAck.
+//
+// DEPRECATED: use MarshalLen instead.
+func (a *AspDownAck) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return a.MarshalLen()
 }

--- a/messages/asp-down-ack_test.go
+++ b/messages/asp-down-ack_test.go
@@ -34,7 +34,7 @@ func TestAspDownAck(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeAspDownAck(b)
+		v, err := ParseAspDownAck(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/asp-down.go
+++ b/messages/asp-down.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -34,50 +35,50 @@ func NewAspDown(info *params.Param) *AspDown {
 	return a
 }
 
-// Serialize returns the byte sequence generated from a AspDown.
-func (a *AspDown) Serialize() ([]byte, error) {
-	b := make([]byte, a.Len())
-	if err := a.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a AspDown.
+func (a *AspDown) MarshalBinary() ([]byte, error) {
+	b := make([]byte, a.MarshalLen())
+	if err := a.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize AspDown")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (a *AspDown) SerializeTo(b []byte) error {
-	if len(b) < a.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (a *AspDown) MarshalTo(b []byte) error {
+	if len(b) < a.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	a.Header.Payload = make([]byte, a.Len()-8)
+	a.Header.Payload = make([]byte, a.MarshalLen()-8)
 
-	if a.InfoString != nil {
-		if err := a.InfoString.SerializeTo(a.Header.Payload); err != nil {
+	if param := a.InfoString; param != nil {
+		if err := param.MarshalTo(a.Header.Payload); err != nil {
 			return err
 		}
 	}
 
-	return a.Header.SerializeTo(b)
+	return a.Header.MarshalTo(b)
 }
 
-// DecodeAspDown decodes given byte sequence as a AspDown.
-func DecodeAspDown(b []byte) (*AspDown, error) {
+// ParseAspDown decodes given byte sequence as a AspDown.
+func ParseAspDown(b []byte) (*AspDown, error) {
 	a := &AspDown{}
-	if err := a.DecodeFromBytes(b); err != nil {
+	if err := a.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (a *AspDown) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (a *AspDown) UnmarshalBinary(b []byte) error {
 	var err error
-	a.Header, err = DecodeHeader(b)
+	a.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(a.Header.Payload)
+	prs, err := params.ParseMultiParams(a.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -94,19 +95,19 @@ func (a *AspDown) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (a *AspDown) SetLength() {
-	if a.InfoString != nil {
-		a.InfoString.SetLength()
+	if param := a.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	a.Header.SetLength()
-	a.Header.Length += uint32(a.Len())
+	a.Header.Length += uint32(a.MarshalLen())
 }
 
-// Len returns the actual length of AspDown.
-func (a *AspDown) Len() int {
+// MarshalLen returns the serial length of AspDown.
+func (a *AspDown) MarshalLen() int {
 	l := 8
-	if a.InfoString != nil {
-		l += a.InfoString.Len()
+	if param := a.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -142,4 +143,44 @@ func (a *AspDown) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (a *AspDown) MessageTypeName() string {
 	return "ASP Down"
+}
+
+// Serialize returns the byte sequence generated from a AspDown.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (a *AspDown) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return a.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (a *AspDown) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return a.MarshalTo(b)
+}
+
+// DecodeAspDown decodes given byte sequence as a AspDown.
+//
+// DEPRECATED: use ParseAspDown instead.
+func DecodeAspDown(b []byte) (*AspDown, error) {
+	log.Println("DEPRECATED: use ParseAspDown instead")
+	return ParseAspDown(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (a *AspDown) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return a.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of AspDown.
+//
+// DEPRECATED: use MarshalLen instead.
+func (a *AspDown) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return a.MarshalLen()
 }

--- a/messages/asp-down_test.go
+++ b/messages/asp-down_test.go
@@ -34,7 +34,7 @@ func TestAspDown(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeAspDown(b)
+		v, err := ParseAspDown(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/asp-inactive-ack.go
+++ b/messages/asp-inactive-ack.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -35,58 +36,58 @@ func NewAspInactiveAck(rtCtx, info *params.Param) *AspInactiveAck {
 	return a
 }
 
-// Serialize returns the byte sequence generated from a AspInactiveAck.
-func (a *AspInactiveAck) Serialize() ([]byte, error) {
-	b := make([]byte, a.Len())
-	if err := a.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a AspInactiveAck.
+func (a *AspInactiveAck) MarshalBinary() ([]byte, error) {
+	b := make([]byte, a.MarshalLen())
+	if err := a.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize AspInactiveAck")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (a *AspInactiveAck) SerializeTo(b []byte) error {
-	if len(b) < a.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (a *AspInactiveAck) MarshalTo(b []byte) error {
+	if len(b) < a.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	a.Header.Payload = make([]byte, a.Len()-8)
+	a.Header.Payload = make([]byte, a.MarshalLen()-8)
 
 	var offset = 0
-	if a.RoutingContext != nil {
-		if err := a.RoutingContext.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.RoutingContext; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += a.RoutingContext.Len()
+		offset += param.MarshalLen()
 	}
 
-	if a.InfoString != nil {
-		if err := a.InfoString.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.InfoString; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
 
-	return a.Header.SerializeTo(b)
+	return a.Header.MarshalTo(b)
 }
 
-// DecodeAspInactiveAck decodes given byte sequence as a AspInactiveAck.
-func DecodeAspInactiveAck(b []byte) (*AspInactiveAck, error) {
+// ParseAspInactiveAck decodes given byte sequence as a AspInactiveAck.
+func ParseAspInactiveAck(b []byte) (*AspInactiveAck, error) {
 	a := &AspInactiveAck{}
-	if err := a.DecodeFromBytes(b); err != nil {
+	if err := a.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (a *AspInactiveAck) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (a *AspInactiveAck) UnmarshalBinary(b []byte) error {
 	var err error
-	a.Header, err = DecodeHeader(b)
+	a.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(a.Header.Payload)
+	prs, err := params.ParseMultiParams(a.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -105,25 +106,25 @@ func (a *AspInactiveAck) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (a *AspInactiveAck) SetLength() {
-	if a.RoutingContext != nil {
-		a.RoutingContext.SetLength()
+	if param := a.RoutingContext; param != nil {
+		param.SetLength()
 	}
-	if a.InfoString != nil {
-		a.InfoString.SetLength()
+	if param := a.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	a.Header.SetLength()
-	a.Header.Length += uint32(a.Len())
+	a.Header.Length += uint32(a.MarshalLen())
 }
 
-// Len returns the actual length of AspInactiveAck.
-func (a *AspInactiveAck) Len() int {
+// MarshalLen returns the serial length of AspInactiveAck.
+func (a *AspInactiveAck) MarshalLen() int {
 	l := 8
-	if a.RoutingContext != nil {
-		l += a.RoutingContext.Len()
+	if param := a.RoutingContext; param != nil {
+		l += param.MarshalLen()
 	}
-	if a.InfoString != nil {
-		l += a.InfoString.Len()
+	if param := a.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -160,4 +161,44 @@ func (a *AspInactiveAck) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (a *AspInactiveAck) MessageTypeName() string {
 	return "ASP Inactive Ack"
+}
+
+// Serialize returns the byte sequence generated from a AspInactiveAck.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (a *AspInactiveAck) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return a.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (a *AspInactiveAck) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return a.MarshalTo(b)
+}
+
+// DecodeAspInactiveAck decodes given byte sequence as a AspInactiveAck.
+//
+// DEPRECATED: use ParseAspInactiveAck instead.
+func DecodeAspInactiveAck(b []byte) (*AspInactiveAck, error) {
+	log.Println("DEPRECATED: use ParseAspInactiveAck instead")
+	return ParseAspInactiveAck(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (a *AspInactiveAck) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return a.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of AspInactiveAck.
+//
+// DEPRECATED: use MarshalLen instead.
+func (a *AspInactiveAck) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return a.MarshalLen()
 }

--- a/messages/asp-inactive-ack_test.go
+++ b/messages/asp-inactive-ack_test.go
@@ -60,7 +60,7 @@ func TestAspInactiveAck(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeAspInactiveAck(b)
+		v, err := ParseAspInactiveAck(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/asp-inactive.go
+++ b/messages/asp-inactive.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -35,58 +36,58 @@ func NewAspInactive(rtCtx, info *params.Param) *AspInactive {
 	return a
 }
 
-// Serialize returns the byte sequence generated from a AspInactive.
-func (a *AspInactive) Serialize() ([]byte, error) {
-	b := make([]byte, a.Len())
-	if err := a.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a AspInactive.
+func (a *AspInactive) MarshalBinary() ([]byte, error) {
+	b := make([]byte, a.MarshalLen())
+	if err := a.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize AspInactive")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (a *AspInactive) SerializeTo(b []byte) error {
-	if len(b) < a.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (a *AspInactive) MarshalTo(b []byte) error {
+	if len(b) < a.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	a.Header.Payload = make([]byte, a.Len()-8)
+	a.Header.Payload = make([]byte, a.MarshalLen()-8)
 
 	var offset = 0
-	if a.RoutingContext != nil {
-		if err := a.RoutingContext.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.RoutingContext; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += a.RoutingContext.Len()
+		offset += param.MarshalLen()
 	}
 
-	if a.InfoString != nil {
-		if err := a.InfoString.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.InfoString; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
 
-	return a.Header.SerializeTo(b)
+	return a.Header.MarshalTo(b)
 }
 
-// DecodeAspInactive decodes given byte sequence as a AspInactive.
-func DecodeAspInactive(b []byte) (*AspInactive, error) {
+// ParseAspInactive decodes given byte sequence as a AspInactive.
+func ParseAspInactive(b []byte) (*AspInactive, error) {
 	a := &AspInactive{}
-	if err := a.DecodeFromBytes(b); err != nil {
+	if err := a.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (a *AspInactive) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (a *AspInactive) UnmarshalBinary(b []byte) error {
 	var err error
-	a.Header, err = DecodeHeader(b)
+	a.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(a.Header.Payload)
+	prs, err := params.ParseMultiParams(a.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -105,25 +106,25 @@ func (a *AspInactive) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (a *AspInactive) SetLength() {
-	if a.RoutingContext != nil {
-		a.RoutingContext.SetLength()
+	if param := a.RoutingContext; param != nil {
+		param.SetLength()
 	}
-	if a.InfoString != nil {
-		a.InfoString.SetLength()
+	if param := a.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	a.Header.SetLength()
-	a.Header.Length += uint32(a.Len())
+	a.Header.Length += uint32(a.MarshalLen())
 }
 
-// Len returns the actual length of AspInactive.
-func (a *AspInactive) Len() int {
+// MarshalLen returns the serial length of AspInactive.
+func (a *AspInactive) MarshalLen() int {
 	l := 8
-	if a.RoutingContext != nil {
-		l += a.RoutingContext.Len()
+	if param := a.RoutingContext; param != nil {
+		l += param.MarshalLen()
 	}
-	if a.InfoString != nil {
-		l += a.InfoString.Len()
+	if param := a.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -160,4 +161,44 @@ func (a *AspInactive) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (a *AspInactive) MessageTypeName() string {
 	return "ASP Inactive"
+}
+
+// Serialize returns the byte sequence generated from a AspInactive.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (a *AspInactive) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return a.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (a *AspInactive) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return a.MarshalTo(b)
+}
+
+// DecodeAspInactive decodes given byte sequence as a AspInactive.
+//
+// DEPRECATED: use ParseAspInactive instead.
+func DecodeAspInactive(b []byte) (*AspInactive, error) {
+	log.Println("DEPRECATED: use ParseAspInactive instead")
+	return ParseAspInactive(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (a *AspInactive) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return a.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of AspInactive.
+//
+// DEPRECATED: use MarshalLen instead.
+func (a *AspInactive) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return a.MarshalLen()
 }

--- a/messages/asp-inactive_test.go
+++ b/messages/asp-inactive_test.go
@@ -60,7 +60,7 @@ func TestAspInactive(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeAspInactive(b)
+		v, err := ParseAspInactive(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/asp-up-ack.go
+++ b/messages/asp-up-ack.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -35,58 +36,58 @@ func NewAspUpAck(aspID, info *params.Param) *AspUpAck {
 	return a
 }
 
-// Serialize returns the byte sequence generated from a AspUpAck.
-func (a *AspUpAck) Serialize() ([]byte, error) {
-	b := make([]byte, a.Len())
-	if err := a.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a AspUpAck.
+func (a *AspUpAck) MarshalBinary() ([]byte, error) {
+	b := make([]byte, a.MarshalLen())
+	if err := a.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize AspUpAck")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (a *AspUpAck) SerializeTo(b []byte) error {
-	if len(b) < a.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (a *AspUpAck) MarshalTo(b []byte) error {
+	if len(b) < a.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	a.Header.Payload = make([]byte, a.Len()-8)
+	a.Header.Payload = make([]byte, a.MarshalLen()-8)
 
 	var offset = 0
-	if a.AspIdentifier != nil {
-		if err := a.AspIdentifier.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.AspIdentifier; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += a.AspIdentifier.Len()
+		offset += param.MarshalLen()
 	}
 
-	if a.InfoString != nil {
-		if err := a.InfoString.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.InfoString; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
 
-	return a.Header.SerializeTo(b)
+	return a.Header.MarshalTo(b)
 }
 
-// DecodeAspUpAck decodes given byte sequence as a AspUpAck.
-func DecodeAspUpAck(b []byte) (*AspUpAck, error) {
+// ParseAspUpAck decodes given byte sequence as a AspUpAck.
+func ParseAspUpAck(b []byte) (*AspUpAck, error) {
 	a := &AspUpAck{}
-	if err := a.DecodeFromBytes(b); err != nil {
+	if err := a.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (a *AspUpAck) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (a *AspUpAck) UnmarshalBinary(b []byte) error {
 	var err error
-	a.Header, err = DecodeHeader(b)
+	a.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(a.Header.Payload)
+	prs, err := params.ParseMultiParams(a.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -105,25 +106,25 @@ func (a *AspUpAck) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (a *AspUpAck) SetLength() {
-	if a.AspIdentifier != nil {
-		a.AspIdentifier.SetLength()
+	if param := a.AspIdentifier; param != nil {
+		param.SetLength()
 	}
-	if a.InfoString != nil {
-		a.InfoString.SetLength()
+	if param := a.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	a.Header.SetLength()
-	a.Header.Length += uint32(a.Len())
+	a.Header.Length += uint32(a.MarshalLen())
 }
 
-// Len returns the actual length of AspUpAck.
-func (a *AspUpAck) Len() int {
+// MarshalLen returns the serial length of AspUpAck.
+func (a *AspUpAck) MarshalLen() int {
 	l := 8
-	if a.AspIdentifier != nil {
-		l += a.AspIdentifier.Len()
+	if param := a.AspIdentifier; param != nil {
+		l += param.MarshalLen()
 	}
-	if a.InfoString != nil {
-		l += a.InfoString.Len()
+	if param := a.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -160,4 +161,44 @@ func (a *AspUpAck) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (a *AspUpAck) MessageTypeName() string {
 	return "ASP Up Ack"
+}
+
+// Serialize returns the byte sequence generated from a AspUpAck.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (a *AspUpAck) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return a.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (a *AspUpAck) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return a.MarshalTo(b)
+}
+
+// DecodeAspUpAck decodes given byte sequence as a AspUpAck.
+//
+// DEPRECATED: use ParseAspUpAck instead.
+func DecodeAspUpAck(b []byte) (*AspUpAck, error) {
+	log.Println("DEPRECATED: use ParseAspUpAck instead")
+	return ParseAspUpAck(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (a *AspUpAck) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return a.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of AspUpAck.
+//
+// DEPRECATED: use MarshalLen instead.
+func (a *AspUpAck) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return a.MarshalLen()
 }

--- a/messages/asp-up-ack_test.go
+++ b/messages/asp-up-ack_test.go
@@ -60,7 +60,7 @@ func TestAspUpAck(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeAspUpAck(b)
+		v, err := ParseAspUpAck(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/asp-up.go
+++ b/messages/asp-up.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -35,58 +36,58 @@ func NewAspUp(aspID, info *params.Param) *AspUp {
 	return a
 }
 
-// Serialize returns the byte sequence generated from a AspUp.
-func (a *AspUp) Serialize() ([]byte, error) {
-	b := make([]byte, a.Len())
-	if err := a.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a AspUp.
+func (a *AspUp) MarshalBinary() ([]byte, error) {
+	b := make([]byte, a.MarshalLen())
+	if err := a.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize AspUp")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (a *AspUp) SerializeTo(b []byte) error {
-	if len(b) < a.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (a *AspUp) MarshalTo(b []byte) error {
+	if len(b) < a.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	a.Header.Payload = make([]byte, a.Len()-8)
+	a.Header.Payload = make([]byte, a.MarshalLen()-8)
 
 	var offset = 0
-	if a.AspIdentifier != nil {
-		if err := a.AspIdentifier.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.AspIdentifier; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += a.AspIdentifier.Len()
+		offset += param.MarshalLen()
 	}
 
-	if a.InfoString != nil {
-		if err := a.InfoString.SerializeTo(a.Header.Payload[offset:]); err != nil {
+	if param := a.InfoString; param != nil {
+		if err := param.MarshalTo(a.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
 
-	return a.Header.SerializeTo(b)
+	return a.Header.MarshalTo(b)
 }
 
-// DecodeAspUp decodes given byte sequence as a AspUp.
-func DecodeAspUp(b []byte) (*AspUp, error) {
+// ParseAspUp decodes given byte sequence as a AspUp.
+func ParseAspUp(b []byte) (*AspUp, error) {
 	a := &AspUp{}
-	if err := a.DecodeFromBytes(b); err != nil {
+	if err := a.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (a *AspUp) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (a *AspUp) UnmarshalBinary(b []byte) error {
 	var err error
-	a.Header, err = DecodeHeader(b)
+	a.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(a.Header.Payload)
+	prs, err := params.ParseMultiParams(a.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -105,25 +106,25 @@ func (a *AspUp) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (a *AspUp) SetLength() {
-	if a.AspIdentifier != nil {
-		a.AspIdentifier.SetLength()
+	if param := a.AspIdentifier; param != nil {
+		param.SetLength()
 	}
-	if a.InfoString != nil {
-		a.InfoString.SetLength()
+	if param := a.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	a.Header.SetLength()
-	a.Header.Length += uint32(a.Len())
+	a.Header.Length += uint32(a.MarshalLen())
 }
 
-// Len returns the actual length of AspUp.
-func (a *AspUp) Len() int {
+// MarshalLen returns the serial length of AspUp.
+func (a *AspUp) MarshalLen() int {
 	l := 8
-	if a.AspIdentifier != nil {
-		l += a.AspIdentifier.Len()
+	if param := a.AspIdentifier; param != nil {
+		l += param.MarshalLen()
 	}
-	if a.InfoString != nil {
-		l += a.InfoString.Len()
+	if param := a.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -160,4 +161,44 @@ func (a *AspUp) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (a *AspUp) MessageTypeName() string {
 	return "ASP Up"
+}
+
+// Serialize returns the byte sequence generated from a AspUp.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (a *AspUp) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return a.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (a *AspUp) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return a.MarshalTo(b)
+}
+
+// DecodeAspUp decodes given byte sequence as a AspUp.
+//
+// DEPRECATED: use ParseAspUp instead.
+func DecodeAspUp(b []byte) (*AspUp, error) {
+	log.Println("DEPRECATED: use ParseAspUp instead")
+	return ParseAspUp(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (a *AspUp) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return a.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of AspUp.
+//
+// DEPRECATED: use MarshalLen instead.
+func (a *AspUp) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return a.MarshalLen()
 }

--- a/messages/asp-up_test.go
+++ b/messages/asp-up_test.go
@@ -60,7 +60,7 @@ func TestAspUp(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeAspUp(b)
+		v, err := ParseAspUp(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/data_test.go
+++ b/messages/data_test.go
@@ -151,7 +151,7 @@ func TestData(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeData(b)
+		v, err := ParseData(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/daud.go
+++ b/messages/daud.go
@@ -5,6 +5,8 @@
 package messages
 
 import (
+	"log"
+
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
 )
@@ -39,68 +41,68 @@ func NewDestinationStateAudit(nwApr, rtCtx, apcs, info *params.Param) *Destinati
 	return d
 }
 
-// Serialize returns the byte sequence generated from a DestinationStateAudit.
-func (d *DestinationStateAudit) Serialize() ([]byte, error) {
-	b := make([]byte, d.Len())
-	if err := d.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a DestinationStateAudit.
+func (d *DestinationStateAudit) MarshalBinary() ([]byte, error) {
+	b := make([]byte, d.MarshalLen())
+	if err := d.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize DestinationStateAudit")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (d *DestinationStateAudit) SerializeTo(b []byte) error {
-	if len(b) < d.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (d *DestinationStateAudit) MarshalTo(b []byte) error {
+	if len(b) < d.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	d.Header.Payload = make([]byte, d.Len()-8)
+	d.Header.Payload = make([]byte, d.MarshalLen()-8)
 
 	var offset = 0
-	if p := d.NetworkAppearance; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.NetworkAppearance; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.RoutingContext; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.RoutingContext; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.AffectedPointCode; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.InfoString; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.InfoString; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
-	return d.Header.SerializeTo(b)
+	return d.Header.MarshalTo(b)
 }
 
-// DecodeDestinationStateAudit decodes given byte sequence as a DestinationStateAudit.
-func DecodeDestinationStateAudit(b []byte) (*DestinationStateAudit, error) {
+// ParseDestinationStateAudit decodes given byte sequence as a DestinationStateAudit.
+func ParseDestinationStateAudit(b []byte) (*DestinationStateAudit, error) {
 	d := &DestinationStateAudit{}
-	if err := d.DecodeFromBytes(b); err != nil {
+	if err := d.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return d, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (d *DestinationStateAudit) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (d *DestinationStateAudit) UnmarshalBinary(b []byte) error {
 	var err error
-	d.Header, err = DecodeHeader(b)
+	d.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode DUNA")
 	}
 
-	prs, err := params.DecodeMultiParams(d.Header.Payload)
+	prs, err := params.ParseMultiParams(d.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode DUNA")
 	}
@@ -123,37 +125,37 @@ func (d *DestinationStateAudit) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (d *DestinationStateAudit) SetLength() {
-	if p := d.NetworkAppearance; p != nil {
-		p.SetLength()
+	if param := d.NetworkAppearance; param != nil {
+		param.SetLength()
 	}
-	if p := d.RoutingContext; p != nil {
-		p.SetLength()
+	if param := d.RoutingContext; param != nil {
+		param.SetLength()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		p.SetLength()
+	if param := d.AffectedPointCode; param != nil {
+		param.SetLength()
 	}
-	if p := d.InfoString; p != nil {
-		p.SetLength()
+	if param := d.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	d.Header.SetLength()
-	d.Header.Length += uint32(d.Len())
+	d.Header.Length += uint32(d.MarshalLen())
 }
 
-// Len returns the actual length of DestinationStateAudit.
-func (d *DestinationStateAudit) Len() int {
+// MarshalLen returns the serial length of DestinationStateAudit.
+func (d *DestinationStateAudit) MarshalLen() int {
 	l := 8
-	if p := d.NetworkAppearance; p != nil {
-		l += p.Len()
+	if param := d.NetworkAppearance; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.RoutingContext; p != nil {
-		l += p.Len()
+	if param := d.RoutingContext; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		l += p.Len()
+	if param := d.AffectedPointCode; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.InfoString; p != nil {
-		l += p.Len()
+	if param := d.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -181,4 +183,44 @@ func (d *DestinationStateAudit) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (d *DestinationStateAudit) MessageTypeName() string {
 	return "Destination Unavailable"
+}
+
+// Serialize returns the byte sequence generated from a DestinationStateAudit.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (d *DestinationStateAudit) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return d.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (d *DestinationStateAudit) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return d.MarshalTo(b)
+}
+
+// DecodeDestinationStateAudit decodes given byte sequence as a DestinationStateAudit.
+//
+// DEPRECATED: use ParseDestinationStateAudit instead.
+func DecodeDestinationStateAudit(b []byte) (*DestinationStateAudit, error) {
+	log.Println("DEPRECATED: use ParseDestinationStateAudit instead")
+	return ParseDestinationStateAudit(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (d *DestinationStateAudit) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return d.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of DestinationStateAudit.
+//
+// DEPRECATED: use MarshalLen instead.
+func (d *DestinationStateAudit) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return d.MarshalLen()
 }

--- a/messages/daud_test.go
+++ b/messages/daud_test.go
@@ -36,7 +36,7 @@ func TestDestinationStateAudit(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeDestinationStateAudit(b)
+		v, err := ParseDestinationStateAudit(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/dava.go
+++ b/messages/dava.go
@@ -5,6 +5,8 @@
 package messages
 
 import (
+	"log"
+
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
 )
@@ -39,68 +41,68 @@ func NewDestinationAvailable(nwApr, rtCtx, apcs, info *params.Param) *Destinatio
 	return d
 }
 
-// Serialize returns the byte sequence generated from a DestinationAvailable.
-func (d *DestinationAvailable) Serialize() ([]byte, error) {
-	b := make([]byte, d.Len())
-	if err := d.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a DestinationAvailable.
+func (d *DestinationAvailable) MarshalBinary() ([]byte, error) {
+	b := make([]byte, d.MarshalLen())
+	if err := d.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize DestinationAvailable")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (d *DestinationAvailable) SerializeTo(b []byte) error {
-	if len(b) < d.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (d *DestinationAvailable) MarshalTo(b []byte) error {
+	if len(b) < d.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	d.Header.Payload = make([]byte, d.Len()-8)
+	d.Header.Payload = make([]byte, d.MarshalLen()-8)
 
 	var offset = 0
-	if p := d.NetworkAppearance; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.NetworkAppearance; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.RoutingContext; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.RoutingContext; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.AffectedPointCode; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.InfoString; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.InfoString; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
-	return d.Header.SerializeTo(b)
+	return d.Header.MarshalTo(b)
 }
 
-// DecodeDestinationAvailable decodes given byte sequence as a DestinationAvailable.
-func DecodeDestinationAvailable(b []byte) (*DestinationAvailable, error) {
+// ParseDestinationAvailable decodes given byte sequence as a DestinationAvailable.
+func ParseDestinationAvailable(b []byte) (*DestinationAvailable, error) {
 	d := &DestinationAvailable{}
-	if err := d.DecodeFromBytes(b); err != nil {
+	if err := d.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return d, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (d *DestinationAvailable) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (d *DestinationAvailable) UnmarshalBinary(b []byte) error {
 	var err error
-	d.Header, err = DecodeHeader(b)
+	d.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode DUNA")
 	}
 
-	prs, err := params.DecodeMultiParams(d.Header.Payload)
+	prs, err := params.ParseMultiParams(d.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode DUNA")
 	}
@@ -123,37 +125,37 @@ func (d *DestinationAvailable) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (d *DestinationAvailable) SetLength() {
-	if p := d.NetworkAppearance; p != nil {
-		p.SetLength()
+	if param := d.NetworkAppearance; param != nil {
+		param.SetLength()
 	}
-	if p := d.RoutingContext; p != nil {
-		p.SetLength()
+	if param := d.RoutingContext; param != nil {
+		param.SetLength()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		p.SetLength()
+	if param := d.AffectedPointCode; param != nil {
+		param.SetLength()
 	}
-	if p := d.InfoString; p != nil {
-		p.SetLength()
+	if param := d.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	d.Header.SetLength()
-	d.Header.Length += uint32(d.Len())
+	d.Header.Length += uint32(d.MarshalLen())
 }
 
-// Len returns the actual length of DestinationAvailable.
-func (d *DestinationAvailable) Len() int {
+// MarshalLen returns the serial length of DestinationAvailable.
+func (d *DestinationAvailable) MarshalLen() int {
 	l := 8
-	if p := d.NetworkAppearance; p != nil {
-		l += p.Len()
+	if param := d.NetworkAppearance; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.RoutingContext; p != nil {
-		l += p.Len()
+	if param := d.RoutingContext; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		l += p.Len()
+	if param := d.AffectedPointCode; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.InfoString; p != nil {
-		l += p.Len()
+	if param := d.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -181,4 +183,44 @@ func (d *DestinationAvailable) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (d *DestinationAvailable) MessageTypeName() string {
 	return "Destination Unavailable"
+}
+
+// Serialize returns the byte sequence generated from a DestinationAvailable.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (d *DestinationAvailable) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return d.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (d *DestinationAvailable) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return d.MarshalTo(b)
+}
+
+// DecodeDestinationAvailable decodes given byte sequence as a DestinationAvailable.
+//
+// DEPRECATED: use ParseDestinationAvailable instead.
+func DecodeDestinationAvailable(b []byte) (*DestinationAvailable, error) {
+	log.Println("DEPRECATED: use ParseDestinationAvailable instead")
+	return ParseDestinationAvailable(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (d *DestinationAvailable) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return d.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of DestinationAvailable.
+//
+// DEPRECATED: use MarshalLen instead.
+func (d *DestinationAvailable) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return d.MarshalLen()
 }

--- a/messages/dava_test.go
+++ b/messages/dava_test.go
@@ -36,7 +36,7 @@ func TestDestinationAvailable(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeDestinationAvailable(b)
+		v, err := ParseDestinationAvailable(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/duna.go
+++ b/messages/duna.go
@@ -5,6 +5,8 @@
 package messages
 
 import (
+	"log"
+
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
 )
@@ -39,68 +41,68 @@ func NewDestinationUnavailable(nwApr, rtCtx, apcs, info *params.Param) *Destinat
 	return d
 }
 
-// Serialize returns the byte sequence generated from a DestinationUnavailable.
-func (d *DestinationUnavailable) Serialize() ([]byte, error) {
-	b := make([]byte, d.Len())
-	if err := d.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a DestinationUnavailable.
+func (d *DestinationUnavailable) MarshalBinary() ([]byte, error) {
+	b := make([]byte, d.MarshalLen())
+	if err := d.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize DestinationUnavailable")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (d *DestinationUnavailable) SerializeTo(b []byte) error {
-	if len(b) < d.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (d *DestinationUnavailable) MarshalTo(b []byte) error {
+	if len(b) < d.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	d.Header.Payload = make([]byte, d.Len()-8)
+	d.Header.Payload = make([]byte, d.MarshalLen()-8)
 
 	var offset = 0
-	if p := d.NetworkAppearance; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.NetworkAppearance; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.RoutingContext; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.RoutingContext; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.AffectedPointCode; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
-		offset += p.Len()
+		offset += param.MarshalLen()
 	}
-	if p := d.InfoString; p != nil {
-		if err := p.SerializeTo(d.Header.Payload[offset:]); err != nil {
+	if param := d.InfoString; param != nil {
+		if err := param.MarshalTo(d.Header.Payload[offset:]); err != nil {
 			return err
 		}
 	}
-	return d.Header.SerializeTo(b)
+	return d.Header.MarshalTo(b)
 }
 
-// DecodeDestinationUnavailable decodes given byte sequence as a DestinationUnavailable.
-func DecodeDestinationUnavailable(b []byte) (*DestinationUnavailable, error) {
+// ParseDestinationUnavailable decodes given byte sequence as a DestinationUnavailable.
+func ParseDestinationUnavailable(b []byte) (*DestinationUnavailable, error) {
 	d := &DestinationUnavailable{}
-	if err := d.DecodeFromBytes(b); err != nil {
+	if err := d.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return d, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (d *DestinationUnavailable) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (d *DestinationUnavailable) UnmarshalBinary(b []byte) error {
 	var err error
-	d.Header, err = DecodeHeader(b)
+	d.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode DUNA")
 	}
 
-	prs, err := params.DecodeMultiParams(d.Header.Payload)
+	prs, err := params.ParseMultiParams(d.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode DUNA")
 	}
@@ -123,37 +125,37 @@ func (d *DestinationUnavailable) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (d *DestinationUnavailable) SetLength() {
-	if p := d.NetworkAppearance; p != nil {
-		p.SetLength()
+	if param := d.NetworkAppearance; param != nil {
+		param.SetLength()
 	}
-	if p := d.RoutingContext; p != nil {
-		p.SetLength()
+	if param := d.RoutingContext; param != nil {
+		param.SetLength()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		p.SetLength()
+	if param := d.AffectedPointCode; param != nil {
+		param.SetLength()
 	}
-	if p := d.InfoString; p != nil {
-		p.SetLength()
+	if param := d.InfoString; param != nil {
+		param.SetLength()
 	}
 
 	d.Header.SetLength()
-	d.Header.Length += uint32(d.Len())
+	d.Header.Length += uint32(d.MarshalLen())
 }
 
-// Len returns the actual length of DestinationUnavailable.
-func (d *DestinationUnavailable) Len() int {
+// MarshalLen returns the serial length of DestinationUnavailable.
+func (d *DestinationUnavailable) MarshalLen() int {
 	l := 8
-	if p := d.NetworkAppearance; p != nil {
-		l += p.Len()
+	if param := d.NetworkAppearance; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.RoutingContext; p != nil {
-		l += p.Len()
+	if param := d.RoutingContext; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.AffectedPointCode; p != nil {
-		l += p.Len()
+	if param := d.AffectedPointCode; param != nil {
+		l += param.MarshalLen()
 	}
-	if p := d.InfoString; p != nil {
-		l += p.Len()
+	if param := d.InfoString; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -181,4 +183,44 @@ func (d *DestinationUnavailable) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (d *DestinationUnavailable) MessageTypeName() string {
 	return "Destination Unavailable"
+}
+
+// Serialize returns the byte sequence generated from a DestinationUnavailable.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (d *DestinationUnavailable) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return d.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (d *DestinationUnavailable) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return d.MarshalTo(b)
+}
+
+// DecodeDestinationUnavailable decodes given byte sequence as a DestinationUnavailable.
+//
+// DEPRECATED: use ParseDestinationUnavailable instead.
+func DecodeDestinationUnavailable(b []byte) (*DestinationUnavailable, error) {
+	log.Println("DEPRECATED: use ParseDestinationUnavailable instead")
+	return ParseDestinationUnavailable(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (d *DestinationUnavailable) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return d.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of DestinationUnavailable.
+//
+// DEPRECATED: use MarshalLen instead.
+func (d *DestinationUnavailable) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return d.MarshalLen()
 }

--- a/messages/duna_test.go
+++ b/messages/duna_test.go
@@ -36,7 +36,7 @@ func TestDestinationUnavailable(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeDestinationUnavailable(b)
+		v, err := ParseDestinationUnavailable(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/error_test.go
+++ b/messages/error_test.go
@@ -48,7 +48,7 @@ func TestError(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeError(b)
+		v, err := ParseError(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/generic_test.go
+++ b/messages/generic_test.go
@@ -35,7 +35,7 @@ func TestGeneric(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeGeneric(b)
+		v, err := ParseGeneric(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/header.go
+++ b/messages/header.go
@@ -7,6 +7,7 @@ package messages
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
 )
 
 // Header is a M3UA common header.
@@ -33,20 +34,20 @@ func NewHeader(version, class, mtype uint8, payload []byte) *Header {
 	return h
 }
 
-// Serialize returns the byte sequence generated from a Header instance.
-func (h *Header) Serialize() ([]byte, error) {
-	b := make([]byte, h.Len())
-	if err := h.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a Header instance.
+func (h *Header) MarshalBinary() ([]byte, error) {
+	b := make([]byte, h.MarshalLen())
+	if err := h.MarshalTo(b); err != nil {
 		return nil, err
 	}
 
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (h *Header) SerializeTo(b []byte) error {
-	if len(b) < h.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (h *Header) MarshalTo(b []byte) error {
+	if len(b) < h.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
 	b[0] = h.Version
@@ -54,26 +55,26 @@ func (h *Header) SerializeTo(b []byte) error {
 	b[2] = h.Class
 	b[3] = h.Type
 	binary.BigEndian.PutUint32(b[4:8], h.Length)
-	copy(b[8:h.Len()], h.Payload)
+	copy(b[8:h.MarshalLen()], h.Payload)
 
 	return nil
 }
 
-// DecodeHeader decodes given byte sequence as a M3UA common header.
-func DecodeHeader(b []byte) (*Header, error) {
+// ParseHeader decodes given byte sequence as a M3UA common header.
+func ParseHeader(b []byte) (*Header, error) {
 	h := &Header{}
-	if err := h.DecodeFromBytes(b); err != nil {
+	if err := h.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 
 	return h, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (h *Header) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (h *Header) UnmarshalBinary(b []byte) error {
 	l := len(b)
 	if l < 8 {
-		return ErrTooShortToDecode
+		return ErrTooShortToParse
 	}
 	h.Version = b[0]
 	h.Reserved = b[1]
@@ -85,8 +86,8 @@ func (h *Header) DecodeFromBytes(b []byte) error {
 	return nil
 }
 
-// Len returns the actual length of Header.
-func (h *Header) Len() int {
+// MarshalLen returns the serial length of Header.
+func (h *Header) MarshalLen() int {
 	return 8 + len(h.Payload)
 }
 
@@ -105,4 +106,44 @@ func (h *Header) String() string {
 		h.Length,
 		h.Payload,
 	)
+}
+
+// Serialize returns the byte sequence generated from a Header.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (h *Header) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return h.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (h *Header) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return h.MarshalTo(b)
+}
+
+// DecodeHeader decodes given byte sequence as a Header.
+//
+// DEPRECATED: use ParseHeader instead.
+func DecodeHeader(b []byte) (*Header, error) {
+	log.Println("DEPRECATED: use ParseHeader instead")
+	return ParseHeader(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (h *Header) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return h.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of Header.
+//
+// DEPRECATED: use MarshalLen instead.
+func (h *Header) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return h.MarshalLen()
 }

--- a/messages/header_test.go
+++ b/messages/header_test.go
@@ -30,7 +30,7 @@ func TestHeader(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeHeader(b)
+		v, err := ParseHeader(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/heartbeat-ack.go
+++ b/messages/heartbeat-ack.go
@@ -6,6 +6,7 @@ package messages
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/wmnsk/go-m3ua/messages/params"
@@ -34,50 +35,50 @@ func NewHeartbeatAck(hbData *params.Param) *HeartbeatAck {
 	return h
 }
 
-// Serialize returns the byte sequence generated from a HeartbeatAck.
-func (h *HeartbeatAck) Serialize() ([]byte, error) {
-	b := make([]byte, h.Len())
-	if err := h.SerializeTo(b); err != nil {
+// MarshalBinary returns the byte sequence generated from a HeartbeatAck.
+func (h *HeartbeatAck) MarshalBinary() ([]byte, error) {
+	b := make([]byte, h.MarshalLen())
+	if err := h.MarshalTo(b); err != nil {
 		return nil, errors.Wrap(err, "failed to serialize HeartbeatAck")
 	}
 	return b, nil
 }
 
-// SerializeTo puts the byte sequence in the byte array given as b.
-func (h *HeartbeatAck) SerializeTo(b []byte) error {
-	if len(b) < h.Len() {
-		return ErrTooShortToSerialize
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (h *HeartbeatAck) MarshalTo(b []byte) error {
+	if len(b) < h.MarshalLen() {
+		return ErrTooShortToMarshalBinary
 	}
 
-	h.Header.Payload = make([]byte, h.Len()-8)
+	h.Header.Payload = make([]byte, h.MarshalLen()-8)
 
-	if h.HeartbeatData != nil {
-		if err := h.HeartbeatData.SerializeTo(h.Header.Payload); err != nil {
+	if param := h.HeartbeatData; param != nil {
+		if err := param.MarshalTo(h.Header.Payload); err != nil {
 			return err
 		}
 	}
 
-	return h.Header.SerializeTo(b)
+	return h.Header.MarshalTo(b)
 }
 
-// DecodeHeartbeatAck decodes given byte sequence as a HeartbeatAck.
-func DecodeHeartbeatAck(b []byte) (*HeartbeatAck, error) {
+// ParseHeartbeatAck decodes given byte sequence as a HeartbeatAck.
+func ParseHeartbeatAck(b []byte) (*HeartbeatAck, error) {
 	h := &HeartbeatAck{}
-	if err := h.DecodeFromBytes(b); err != nil {
+	if err := h.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return h, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
-func (h *HeartbeatAck) DecodeFromBytes(b []byte) error {
+// UnmarshalBinary sets the values retrieved from byte sequence in a M3UA common header.
+func (h *HeartbeatAck) UnmarshalBinary(b []byte) error {
 	var err error
-	h.Header, err = DecodeHeader(b)
+	h.Header, err = ParseHeader(b)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Header")
 	}
 
-	prs, err := params.DecodeMultiParams(h.Header.Payload)
+	prs, err := params.ParseMultiParams(h.Header.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode Params")
 	}
@@ -94,19 +95,19 @@ func (h *HeartbeatAck) DecodeFromBytes(b []byte) error {
 
 // SetLength sets the length in Length field.
 func (h *HeartbeatAck) SetLength() {
-	if h.HeartbeatData != nil {
-		h.HeartbeatData.SetLength()
+	if param := h.HeartbeatData; param != nil {
+		param.SetLength()
 	}
 
 	h.Header.SetLength()
-	h.Header.Length += uint32(h.Len())
+	h.Header.Length += uint32(h.MarshalLen())
 }
 
-// Len returns the actual length of HeartbeatAck.
-func (h *HeartbeatAck) Len() int {
+// MarshalLen returns the serial length of HeartbeatAck.
+func (h *HeartbeatAck) MarshalLen() int {
 	l := 8
-	if h.HeartbeatData != nil {
-		l += h.HeartbeatData.Len()
+	if param := h.HeartbeatData; param != nil {
+		l += param.MarshalLen()
 	}
 	return l
 }
@@ -142,4 +143,44 @@ func (h *HeartbeatAck) MessageClassName() string {
 // MessageTypeName returns the name of message type.
 func (h *HeartbeatAck) MessageTypeName() string {
 	return "Heartbeat Ack"
+}
+
+// Serialize returns the byte sequence generated from a HeartbeatAck.
+//
+// DEPRECATED: use MarshalBinary instead.
+func (h *HeartbeatAck) Serialize() ([]byte, error) {
+	log.Println("DEPRECATED: MarshalBinary instead")
+	return h.MarshalBinary()
+}
+
+// SerializeTo puts the byte sequence in the byte array given as b.
+//
+// DEPRECATED: use MarshalTo instead.
+func (h *HeartbeatAck) SerializeTo(b []byte) error {
+	log.Println("DEPRECATED: MarshalTo instead")
+	return h.MarshalTo(b)
+}
+
+// DecodeHeartbeatAck decodes given byte sequence as a HeartbeatAck.
+//
+// DEPRECATED: use ParseHeartbeatAck instead.
+func DecodeHeartbeatAck(b []byte) (*HeartbeatAck, error) {
+	log.Println("DEPRECATED: use ParseHeartbeatAck instead")
+	return ParseHeartbeatAck(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a M3UA common header.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (h *HeartbeatAck) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return h.UnmarshalBinary(b)
+}
+
+// Len returns the serial length of HeartbeatAck.
+//
+// DEPRECATED: use MarshalLen instead.
+func (h *HeartbeatAck) Len() int {
+	log.Println("DEPRECATED: use MarshalLen instead")
+	return h.MarshalLen()
 }

--- a/messages/heartbeat-ack_test.go
+++ b/messages/heartbeat-ack_test.go
@@ -27,7 +27,7 @@ func TestHeartbeatAck(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeHeartbeatAck(b)
+		v, err := ParseHeartbeatAck(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/heartbeat_test.go
+++ b/messages/heartbeat_test.go
@@ -27,7 +27,7 @@ func TestHeartbeat(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeHeartbeat(b)
+		v, err := ParseHeartbeat(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/notify_test.go
+++ b/messages/notify_test.go
@@ -162,7 +162,7 @@ func TestNotify(t *testing.T) {
 	}
 
 	runTests(t, cases, func(b []byte) (serializeable, error) {
-		v, err := DecodeNotify(b)
+		v, err := ParseNotify(b)
 		if err != nil {
 			return nil, err
 		}

--- a/messages/params/affected-pointcode.go
+++ b/messages/params/affected-pointcode.go
@@ -36,21 +36,21 @@ type PointCodeWithMask struct {
 	PointCode uint32
 }
 
-// Serialize creates the 32bit-sized []byte from PointCodeWithMask.
-func (p *PointCodeWithMask) Serialize() ([]byte, error) {
+// MarshalBinary creates the 32bit-sized []byte from PointCodeWithMask.
+func (p *PointCodeWithMask) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 4)
 	// to be written?
 }
 
-func (p *PointCodeWithMask) SerializeTo(b []bytes) error {
+func (p *PointCodeWithMask) MarshalTo(b []bytes) error {
 	// to be written?
 }
 
-func (p *PointCodeWithMask) Decode(b []bytes) (*PointCodeWithMask, error) {
+func (p *PointCodeWithMask) Parse(b []bytes) (*PointCodeWithMask, error) {
 	// to be written?
 }
 
-func (p *PointCodeWithMask) DecodeFromBytes(b []bytes) error {
+func (p *PointCodeWithMask) UnmarshalBinary(b []bytes) error {
 	// to be written?
 }
 */

--- a/messages/params/deregistration-result.go
+++ b/messages/params/deregistration-result.go
@@ -4,6 +4,8 @@
 
 package params
 
+import "log"
+
 // DeregResultPayload is the payload of DeregistrationResult.
 type DeregResultPayload struct {
 	RoutingContext, DeregistrationStatus *Param
@@ -33,25 +35,25 @@ func (p *Param) DeregistrationResult() (*DeregResultPayload, error) {
 		return nil, ErrInvalidType
 	}
 
-	d, err := DecodeDeregResultPayload(p.Data)
+	d, err := ParseDeregResultPayload(p.Data)
 	if err != nil {
 		return nil, err
 	}
 	return d, nil
 }
 
-// DecodeDeregResultPayload decodes given byte sequence as a DeregResultPayload.
-func DecodeDeregResultPayload(b []byte) (*DeregResultPayload, error) {
+// ParseDeregResultPayload decodes given byte sequence as a DeregResultPayload.
+func ParseDeregResultPayload(b []byte) (*DeregResultPayload, error) {
 	d := &DeregResultPayload{}
-	if err := d.DecodeFromBytes(b); err != nil {
+	if err := d.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return d, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a Param.
-func (d *DeregResultPayload) DecodeFromBytes(b []byte) error {
-	ps, err := DecodeMultiParams(b)
+// UnmarshalBinary sets the values retrieved from byte sequence in a Param.
+func (d *DeregResultPayload) UnmarshalBinary(b []byte) error {
+	ps, err := ParseMultiParams(b)
 	if err != nil {
 		return err
 	}
@@ -68,4 +70,20 @@ func (d *DeregResultPayload) DecodeFromBytes(b []byte) error {
 		}
 	}
 	return nil
+}
+
+// DecodeDeregResultPayload decodes given byte sequence as a DeregResultPayload.
+//
+// DEPRECATED: use ParseDeregResultPayload instead.
+func DecodeDeregResultPayload(b []byte) (*DeregResultPayload, error) {
+	log.Println("DEPRECATED: use ParseDeregResultPayload instead")
+	return ParseDeregResultPayload(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a Param.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (d *DeregResultPayload) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return d.UnmarshalBinary(b)
 }

--- a/messages/params/originating-point-code-list.go
+++ b/messages/params/originating-point-code-list.go
@@ -28,21 +28,21 @@ type PointCodeWithMask struct {
 	PointCode uint32
 }
 
-// Serialize creates the 32bit-sized []byte from PointCodeWithMask.
-func (p *PointCodeWithMask) Serialize() ([]byte, error) {
+// MarshalBinary creates the 32bit-sized []byte from PointCodeWithMask.
+func (p *PointCodeWithMask) MarshalBinary() ([]byte, error) {
 	b := make([]byte, 4)
 	// to be written?
 }
 
-func (p *PointCodeWithMask) SerializeTo(b []bytes) error {
+func (p *PointCodeWithMask) MarshalTo(b []bytes) error {
 	// to be written?
 }
 
-func (p *PointCodeWithMask) Decode(b []bytes) (*PointCodeWithMask, error) {
+func (p *PointCodeWithMask) Parse(b []bytes) (*PointCodeWithMask, error) {
 	// to be written?
 }
 
-func (p *PointCodeWithMask) DecodeFromBytes(b []bytes) error {
+func (p *PointCodeWithMask) UnmarshalBinary(b []bytes) error {
 	// to be written?
 }
 */

--- a/messages/params/params_test.go
+++ b/messages/params/params_test.go
@@ -220,7 +220,7 @@ func TestParams(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("encode/"+c.name, func(t *testing.T) {
-			got, err := c.structured.Serialize()
+			got, err := c.structured.MarshalBinary()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -230,7 +230,7 @@ func TestParams(t *testing.T) {
 		})
 
 		t.Run("decode/"+c.name, func(t *testing.T) {
-			got, err := Decode(c.serialized)
+			got, err := Parse(c.serialized)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -242,7 +242,7 @@ func TestParams(t *testing.T) {
 
 }
 
-func TestDecodeMultiParams(t *testing.T) {
+func TestParseMultiParams(t *testing.T) {
 	cases := []struct {
 		name       string
 		structured []*Param
@@ -264,7 +264,7 @@ func TestDecodeMultiParams(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		got, err := DecodeMultiParams(c.serialized)
+		got, err := ParseMultiParams(c.serialized)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/messages/params/registration-result.go
+++ b/messages/params/registration-result.go
@@ -4,6 +4,8 @@
 
 package params
 
+import "log"
+
 // RegistrationResultPayload is the payload of RegistrationResult.
 type RegistrationResultPayload struct {
 	LocalRoutingKeyIdentifier, RegistrationStatus, RoutingContext *Param
@@ -35,25 +37,25 @@ func (p *Param) RegistrationResult() (*RegistrationResultPayload, error) {
 		return nil, ErrInvalidType
 	}
 
-	d, err := DecodeRegistrationResultPayload(p.Data)
+	d, err := ParseRegistrationResultPayload(p.Data)
 	if err != nil {
 		return nil, err
 	}
 	return d, nil
 }
 
-// DecodeRegistrationResultPayload decodes given byte sequence as a RegistrationResultPayload.
-func DecodeRegistrationResultPayload(b []byte) (*RegistrationResultPayload, error) {
+// ParseRegistrationResultPayload decodes given byte sequence as a RegistrationResultPayload.
+func ParseRegistrationResultPayload(b []byte) (*RegistrationResultPayload, error) {
 	d := &RegistrationResultPayload{}
-	if err := d.DecodeFromBytes(b); err != nil {
+	if err := d.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return d, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a Param.
-func (d *RegistrationResultPayload) DecodeFromBytes(b []byte) error {
-	ps, err := DecodeMultiParams(b)
+// UnmarshalBinary sets the values retrieved from byte sequence in a Param.
+func (d *RegistrationResultPayload) UnmarshalBinary(b []byte) error {
+	ps, err := ParseMultiParams(b)
 	if err != nil {
 		return err
 	}
@@ -66,4 +68,20 @@ func (d *RegistrationResultPayload) DecodeFromBytes(b []byte) error {
 	d.RoutingContext = ps[2]
 
 	return nil
+}
+
+// DecodeRegistrationResultPayload decodes given byte sequence as a RegistrationResultPayload.
+//
+// DEPRECATED: use ParseRegistrationResultPayload instead.
+func DecodeRegistrationResultPayload(b []byte) (*RegistrationResultPayload, error) {
+	log.Println("DEPRECATED: use ParseRegistrationResultPayload instead")
+	return ParseRegistrationResultPayload(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a Param.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (d *RegistrationResultPayload) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return d.UnmarshalBinary(b)
 }

--- a/messages/params/routing-key.go
+++ b/messages/params/routing-key.go
@@ -4,6 +4,8 @@
 
 package params
 
+import "log"
+
 // RoutingKeyPayload is the payload of RoutingKey.
 type RoutingKeyPayload struct {
 	LocalRoutingKeyIdentifier, RoutingContext, TrafficModeType, DestinationPointCode, NetworkAppearance, ServiceIndicators, OriginatingPointCodeList *Param
@@ -45,25 +47,25 @@ func (p *Param) RoutingKey() (*RoutingKeyPayload, error) {
 		return nil, ErrInvalidType
 	}
 
-	r, err := DecodeRoutingKeyPayload(p.Data)
+	r, err := ParseRoutingKeyPayload(p.Data)
 	if err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 
-// DecodeRoutingKeyPayload decodes given byte sequence as a RoutingKeyPayload.
-func DecodeRoutingKeyPayload(b []byte) (*RoutingKeyPayload, error) {
+// ParseRoutingKeyPayload decodes given byte sequence as a RoutingKeyPayload.
+func ParseRoutingKeyPayload(b []byte) (*RoutingKeyPayload, error) {
 	r := &RoutingKeyPayload{}
-	if err := r.DecodeFromBytes(b); err != nil {
+	if err := r.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 
-// DecodeFromBytes sets the values retrieved from byte sequence in a Param.
-func (r *RoutingKeyPayload) DecodeFromBytes(b []byte) error {
-	ps, err := DecodeMultiParams(b)
+// UnmarshalBinary sets the values retrieved from byte sequence in a Param.
+func (r *RoutingKeyPayload) UnmarshalBinary(b []byte) error {
+	ps, err := ParseMultiParams(b)
 	if err != nil {
 		return err
 	}
@@ -92,4 +94,20 @@ func (r *RoutingKeyPayload) DecodeFromBytes(b []byte) error {
 		}
 	}
 	return nil
+}
+
+// DecodeRoutingKeyPayload decodes given byte sequence as a RoutingKeyPayload.
+//
+// DEPRECATED: use ParseRoutingKeyPayload instead.
+func DecodeRoutingKeyPayload(b []byte) (*RoutingKeyPayload, error) {
+	log.Println("DEPRECATED: use ParseRoutingKeyPayload instead")
+	return ParseRoutingKeyPayload(b)
+}
+
+// DecodeFromBytes sets the values retrieved from byte sequence in a Param.
+//
+// DEPRECATED: use UnmarshalBinary instead.
+func (r *RoutingKeyPayload) DecodeFromBytes(b []byte) error {
+	log.Println("DEPRECATED: use UnmarshalBinary instead")
+	return r.UnmarshalBinary(b)
 }

--- a/messages/testutils.go
+++ b/messages/testutils.go
@@ -17,8 +17,8 @@ import (
 )
 
 type serializeable interface {
-	Serialize() ([]byte, error)
-	Len() int
+	MarshalBinary() ([]byte, error)
+	MarshalLen() int
 }
 
 type testCase struct {
@@ -46,7 +46,7 @@ func runTests(t *testing.T, cases []testCase, decode decoderFunc) {
 			})
 
 			t.Run("encode", func(t *testing.T) {
-				b, err := c.structured.Serialize()
+				b, err := c.structured.MarshalBinary()
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -57,7 +57,7 @@ func runTests(t *testing.T, cases []testCase, decode decoderFunc) {
 			})
 
 			t.Run("len", func(t *testing.T) {
-				if got, want := c.structured.Len(), len(c.serialized); got != want {
+				if got, want := c.structured.MarshalLen(), len(c.serialized); got != want {
 					t.Fatalf("got %v want %v", got, want)
 				}
 			})
@@ -67,7 +67,7 @@ func runTests(t *testing.T, cases []testCase, decode decoderFunc) {
 				if _, ok := c.structured.(*Header); ok {
 					return
 				}
-				decoded, err := Decode(c.serialized)
+				decoded, err := Parse(c.serialized)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
Replaced names of functions that is related to encoding/decoding messages/params. The original ones are kept as they are for compatibility.

Serialize => MarshalBinary
SerializeTo => MarshalTo
DecodeX => ParseX
DecodeFromBytes => UnmarshalBinary
Len => MarshalLen
