### PR TITLE
Closing M3UA connection on any sctp read error, as io.EOF means the c…

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -6,7 +6,6 @@ package m3ua
 
 import (
 	"context"
-	"io"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -210,9 +209,6 @@ func (c *Conn) monitor(ctx context.Context) {
 			// Read from conn to see something coming from the peer.
 			n, info, err := c.sctpConn.SCTPRead(buf)
 			if err != nil {
-				if err == io.EOF {
-					continue
-				}
 				c.Close()
 				return
 			}


### PR DESCRIPTION
…onnection was interrupted, so we can properly handle link problem in the higher level logic.