### PR TITLE
Fix channel state when message is unknown

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -174,6 +174,7 @@ func (c *Conn) handleSignals(ctx context.Context, m3 messages.M3UA) {
 	// Others: SSNM and RKM is not implemented.
 	default:
 		c.errChan <- NewErrUnsupportedMessage(m3)
+		c.stateChan <- c.state
 	}
 }
 


### PR DESCRIPTION
When remote M3UA server sends unknown message, like DUNA, there is a single ERR response, and client stopping processing any further m3ua data as state is not updated. Fix.
