### PR TITLE
Write to stream

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -108,6 +108,32 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 	return n, nil
 }
 
+// Write writes data to the connection.
+func (c *Conn) WriteToStream(b []byte, stream_id uint16) (n int, err error) {
+        if c.state != StateAspActive {
+                return 0, ErrNotEstablished
+        }
+        d, err := messages.NewData(
+                c.cfg.NetworkAppearance, c.cfg.RoutingContexts, params.NewProtocolData(
+                        c.cfg.OriginatingPointCode, c.cfg.DestinationPointCode,
+                        c.cfg.ServiceIndicator, c.cfg.NetworkIndicator,
+                        c.cfg.MessagePriority, c.cfg.SignalingLinkSelection, b,
+                ), c.cfg.CorrelationID,
+        ).MarshalBinary()
+        if err != nil {
+                return 0, err
+        }
+
+        c.sctpInfo.Stream = stream_id
+        n, err = c.sctpConn.SCTPWrite(d, c.sctpInfo)
+        if err != nil {
+                return 0, err
+        }
+
+        n += len(d)
+        return n, nil
+}
+
 // WriteSignal writes any type of M3UA signals on top of SCTP Connection.
 func (c *Conn) WriteSignal(m3 messages.M3UA) (n int, err error) {
 	n = m3.MarshalLen()

--- a/fsm.go
+++ b/fsm.go
@@ -174,6 +174,7 @@ func (c *Conn) handleSignals(ctx context.Context, m3 messages.M3UA) {
 	// Others: SSNM and RKM is not implemented.
 	default:
 		c.errChan <- NewErrUnsupportedMessage(m3)
+		c.stateChan <- c.state
 	}
 }
 


### PR DESCRIPTION
Working with production M3UA servers requires writing to a SCTP stream > 0, so it's a primitive to allow choosing SCTP stream for the write