### PR TITLE
enh: improves thread safety for m3ua connection state

### DIFF
--- a/aspsm.go
+++ b/aspsm.go
@@ -16,7 +16,7 @@ func (c *Conn) initiateASPSM() error {
 	return nil
 }
 func (c *Conn) handleAspUp(aspUp *messages.AspUp) error {
-	if c.state != StateAspDown {
+	if c.State() != StateAspDown {
 		return NewErrUnexpectedMessage(aspUp)
 
 	}
@@ -37,7 +37,7 @@ func (c *Conn) handleAspUp(aspUp *messages.AspUp) error {
 }
 
 func (c *Conn) handleAspUpAck(aspUpAck *messages.AspUpAck) error {
-	if c.state != StateAspDown {
+	if c.State() != StateAspDown {
 		return NewErrUnexpectedMessage(aspUpAck)
 	}
 	if c.sctpInfo.Stream != 0 {
@@ -48,7 +48,7 @@ func (c *Conn) handleAspUpAck(aspUpAck *messages.AspUpAck) error {
 }
 
 func (c *Conn) handleAspDown(aspDown *messages.AspDown) error {
-	switch c.state {
+	switch c.State() {
 	case StateAspInactive, StateAspActive:
 		return NewErrUnexpectedMessage(aspDown)
 	}
@@ -66,7 +66,7 @@ func (c *Conn) handleAspDown(aspDown *messages.AspDown) error {
 }
 
 func (c *Conn) handleAspDownAck(aspDownAck *messages.AspDownAck) error {
-	switch c.state {
+	switch c.State() {
 	case StateAspInactive, StateAspActive:
 		return NewErrUnexpectedMessage(aspDownAck)
 	}

--- a/asptm.go
+++ b/asptm.go
@@ -67,7 +67,7 @@ func (c *Conn) heartbeat(ctx context.Context) {
 }
 
 func (c *Conn) handleAspActive(aspActive *messages.AspActive) error {
-	if c.state != StateAspInactive {
+	if c.State() != StateAspInactive {
 		return NewErrUnexpectedMessage(aspActive)
 	}
 
@@ -81,7 +81,7 @@ func (c *Conn) handleAspActive(aspActive *messages.AspActive) error {
 }
 
 func (c *Conn) handleAspActiveAck(aspAcAck *messages.AspActiveAck) error {
-	if c.state != StateAspInactive {
+	if c.State() != StateAspInactive {
 		return NewErrUnexpectedMessage(aspAcAck)
 	}
 
@@ -91,7 +91,7 @@ func (c *Conn) handleAspActiveAck(aspAcAck *messages.AspActiveAck) error {
 }
 
 func (c *Conn) handleAspInactive(aspInactive *messages.AspInactive) error {
-	if c.state != StateAspActive {
+	if c.State() != StateAspActive {
 		return NewErrUnexpectedMessage(aspInactive)
 	}
 
@@ -105,7 +105,7 @@ func (c *Conn) handleAspInactive(aspInactive *messages.AspInactive) error {
 }
 
 func (c *Conn) handleAspInactiveAck(aspAcAck *messages.AspInactiveAck) error {
-	if c.state != StateAspActive {
+	if c.State() != StateAspActive {
 		return NewErrUnexpectedMessage(aspAcAck)
 	}
 
@@ -115,7 +115,7 @@ func (c *Conn) handleAspInactiveAck(aspAcAck *messages.AspInactiveAck) error {
 }
 
 func (c *Conn) handleHeartbeat(beat *messages.Heartbeat) error {
-	if c.state != StateAspActive {
+	if c.State() != StateAspActive {
 		return NewErrUnexpectedMessage(beat)
 	}
 
@@ -128,7 +128,7 @@ func (c *Conn) handleHeartbeat(beat *messages.Heartbeat) error {
 }
 
 func (c *Conn) handleHeartbeatAck(beatAck *messages.HeartbeatAck) error {
-	if c.state != StateAspActive {
+	if c.State() != StateAspActive {
 		return NewErrUnexpectedMessage(beatAck)
 	}
 

--- a/client.go
+++ b/client.go
@@ -20,7 +20,7 @@ import (
 func Dial(ctx context.Context, net string, laddr, raddr *sctp.SCTPAddr, cfg *Config) (*Conn, error) {
 	var err error
 	conn := &Conn{
-		mu:          new(sync.Mutex),
+		muState:     new(sync.RWMutex),
 		mode:        modeClient,
 		stateChan:   make(chan State),
 		established: make(chan struct{}),

--- a/management.go
+++ b/management.go
@@ -8,7 +8,7 @@ import "github.com/wmnsk/go-m3ua/messages"
 
 // XXX - implement!
 func (c *Conn) handleError(e *messages.Error) error {
-	switch c.state {
+	switch c.State() {
 	case StateSCTPCDI, StateSCTPRI:
 		return NewErrUnexpectedMessage(e)
 	}
@@ -18,7 +18,7 @@ func (c *Conn) handleError(e *messages.Error) error {
 
 // XXX - implement!
 func (c *Conn) handleNotify(e *messages.Notify) error {
-	switch c.state {
+	switch c.State() {
 	case StateSCTPCDI, StateSCTPRI:
 		return NewErrUnexpectedMessage(e)
 	}

--- a/server.go
+++ b/server.go
@@ -43,7 +43,7 @@ func Listen(net string, laddr *sctp.SCTPAddr, cfg *Config) (*Listener, error) {
 // Other signals are automatically handled background in another goroutine.
 func (l *Listener) Accept(ctx context.Context) (*Conn, error) {
 	conn := &Conn{
-		mu:          new(sync.Mutex),
+		muState:     new(sync.RWMutex),
 		mode:        modeServer,
 		stateChan:   make(chan State),
 		established: make(chan struct{}),

--- a/transfer.go
+++ b/transfer.go
@@ -13,9 +13,7 @@ import (
 
 func (c *Conn) handleData(ctx context.Context, data *messages.Data) {
 	err := func() error {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		if c.state != StateAspActive {
+		if c.State() != StateAspActive {
 			c.errChan <- NewErrUnexpectedMessage(data)
 			return errors.New(data.String())
 		}


### PR DESCRIPTION
Testing revealed numerous race conditions related to the M3UA connection's status. 
This PR provides an enhancement for such race conditions, making it thread-safe.