### PR TITLE
enh: improves thread safety for sctp stream id

### DIFF
--- a/aspsm.go
+++ b/aspsm.go
@@ -20,8 +20,8 @@ func (c *Conn) handleAspUp(aspUp *messages.AspUp) error {
 		return NewErrUnexpectedMessage(aspUp)
 
 	}
-	if c.sctpInfo.Stream != 0 {
-		return NewErrInvalidSCTPStreamID(c.sctpInfo.Stream)
+	if c.StreamID() != 0 {
+		return NewErrInvalidSCTPStreamID(c.StreamID())
 	}
 
 	if _, err := c.WriteSignal(
@@ -40,8 +40,8 @@ func (c *Conn) handleAspUpAck(aspUpAck *messages.AspUpAck) error {
 	if c.State() != StateAspDown {
 		return NewErrUnexpectedMessage(aspUpAck)
 	}
-	if c.sctpInfo.Stream != 0 {
-		return NewErrInvalidSCTPStreamID(c.sctpInfo.Stream)
+	if c.StreamID() != 0 {
+		return NewErrInvalidSCTPStreamID(c.StreamID())
 	}
 
 	return nil
@@ -52,8 +52,8 @@ func (c *Conn) handleAspDown(aspDown *messages.AspDown) error {
 	case StateAspInactive, StateAspActive:
 		return NewErrUnexpectedMessage(aspDown)
 	}
-	if c.sctpInfo.Stream != 0 {
-		return NewErrInvalidSCTPStreamID(c.sctpInfo.Stream)
+	if c.StreamID() != 0 {
+		return NewErrInvalidSCTPStreamID(c.StreamID())
 	}
 
 	// XXX - Validate the params.
@@ -70,8 +70,8 @@ func (c *Conn) handleAspDownAck(aspDownAck *messages.AspDownAck) error {
 	case StateAspInactive, StateAspActive:
 		return NewErrUnexpectedMessage(aspDownAck)
 	}
-	if c.sctpInfo.Stream != 0 {
-		return NewErrInvalidSCTPStreamID(c.sctpInfo.Stream)
+	if c.StreamID() != 0 {
+		return NewErrInvalidSCTPStreamID(c.StreamID())
 	}
 
 	return nil

--- a/client.go
+++ b/client.go
@@ -21,6 +21,7 @@ func Dial(ctx context.Context, net string, laddr, raddr *sctp.SCTPAddr, cfg *Con
 	var err error
 	conn := &Conn{
 		muState:     new(sync.RWMutex),
+		muSctpInfo:  new(sync.RWMutex),
 		mode:        modeClient,
 		stateChan:   make(chan State),
 		established: make(chan struct{}),

--- a/fsm.go
+++ b/fsm.go
@@ -50,7 +50,6 @@ func (c *Conn) handleStateUpdate(current State) error {
 func (c *Conn) handleStateUpdateAsClient(current, previous State) error {
 	switch current {
 	case StateAspDown:
-		c.sctpInfo.Stream = 0
 		return c.initiateASPSM()
 	case StateAspInactive:
 		return c.initiateASPTM()

--- a/server.go
+++ b/server.go
@@ -44,6 +44,7 @@ func Listen(net string, laddr *sctp.SCTPAddr, cfg *Config) (*Listener, error) {
 func (l *Listener) Accept(ctx context.Context) (*Conn, error) {
 	conn := &Conn{
 		muState:     new(sync.RWMutex),
+		muSctpInfo:  new(sync.RWMutex),
 		mode:        modeServer,
 		stateChan:   make(chan State),
 		established: make(chan struct{}),


### PR DESCRIPTION
This PR provides thread-safe access to SCTP stream ID, as well as safe modifications for management messages and WriteToStream.