### PR TITLE
feat: features writing with dynamic mtp3 protocol data

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -30,11 +30,6 @@ func (c *Conn) handleData(ctx context.Context, data *messages.Data) {
 		return
 	}
 
-	if c.cfg.OriginatingPointCode != pd.DestinationPointCode {
-		c.errChan <- NewErrUnexpectedMessage(data)
-		return
-	}
-
 	select {
 	case c.dataChan <- pd:
 		return


### PR DESCRIPTION
This PR provides a useful and handy feature for writing on an SCTP connection with specific MTP3 protocol data. 
This allows writing data for multiple services on the same SCTP connection with the service-indicator (SI), and it also allows writing data with different SLS, OPC, and DPC. 