### PR TITLE
feat: features usage of the exact negotiated stream id limit

### DIFF
--- a/aspsm.go
+++ b/aspsm.go
@@ -17,6 +17,7 @@ func (c *Conn) initiateASPSM() error {
 }
 func (c *Conn) handleAspUp(aspUp *messages.AspUp) error {
 	if c.State() != StateAspDown {
+		defer c.Close() // Provided to handle bugs from peer STPs
 		return NewErrUnexpectedMessage(aspUp)
 
 	}
@@ -48,6 +49,7 @@ func (c *Conn) handleAspUpAck(aspUpAck *messages.AspUpAck) error {
 }
 
 func (c *Conn) handleAspDown(aspDown *messages.AspDown) error {
+	c.Close() // Closing the connection to close the dataChan, to avoid keeping the Read function keeping blocked on the channel.
 	switch c.State() {
 	case StateAspInactive, StateAspActive:
 		return NewErrUnexpectedMessage(aspDown)

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ func NewHeartbeatInfo(interval, timer time.Duration, data []byte) *HeartbeatInfo
 	}
 }
 
-// Config is a configration that defines a M3UA server.
+// Config is a configuration that defines a M3UA server.
 type Config struct {
 	*HeartbeatInfo
 	AspIdentifier          *params.Param

--- a/fsm.go
+++ b/fsm.go
@@ -25,6 +25,18 @@ const (
 	StateSCTPRI
 )
 
+var statuses = map[State]string{
+	StateAspDown:     "AspDown",
+	StateAspInactive: "AspInactive",
+	StateAspActive:   "AspActive",
+	StateSCTPCDI:     "SCTPCDI",
+	StateSCTPRI:      "SCTPRI",
+}
+
+func (s State) String() string {
+	return statuses[s]
+}
+
 func (c *Conn) handleStateUpdate(current State) error {
 	c.muState.Lock()
 	defer c.muState.Unlock()

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.23
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/ishidawataru/sctp v0.0.0-20250425063137-c91d9fd4afaf
+	github.com/ishidawataru/sctp v0.0.0-20250427101207-53eab83c1cf6
 	github.com/pascaldekloe/goe v0.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/ishidawataru/sctp v0.0.0-20250425063137-c91d9fd4afaf h1:Yk0+ELKOCwbQ3ysGeTYMQYZJMb1rEj7VPTRXHqaEasM=
 github.com/ishidawataru/sctp v0.0.0-20250425063137-c91d9fd4afaf/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
+github.com/ishidawataru/sctp v0.0.0-20250427101207-53eab83c1cf6 h1:BcV9jRUmgOhP6dWHo1awB1QQQjGMRUuS9E4/lmwcbQY=
+github.com/ishidawataru/sctp v0.0.0-20250427101207-53eab83c1cf6/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/pascaldekloe/goe v0.1.1 h1:Ah6WQ56rZONR3RW3qWa2NCZ6JAVvSpUcoLBaOmYFt9Q=
 github.com/pascaldekloe/goe v0.1.1/go.mod h1:KSyfaxQOh0HZPjDP1FL/kFtbqYqrALJTaMafFUIccqU=

--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"sync"
 	"time"
@@ -64,6 +65,14 @@ func (l *Listener) Accept(ctx context.Context) (*Conn, error) {
 	conn.sctpConn, ok = c.(*sctp.SCTPConn)
 	if !ok {
 		return nil, errors.New("failed to assert conn")
+	}
+
+	// Get the maximum stream ID negotiated with the peer in the INIT and INIT-ACK
+	r, err := conn.sctpConn.GetStatus()
+	if err != nil {
+		log.Printf("go-m3ua: failed to retrive sctpConnection status for Dial: %v", err)
+	} else {
+		conn.MaxMessageStreamID = r.Ostreams - 1 // the maximum allowed stream value for normal messages must vary from 1 to max, and for a management message it is already set to 0
 	}
 
 	go func() {


### PR DESCRIPTION
Hi @wmnsk 

This PR updates to the latest Ishida Wataru SCTP dependency library. With this update, we feature getting the maximum negotiated stream ID, which can be used by the user. Exceeding the max negotiated stream ID will throw an error from the system.
