### PR TITLE
update to latest sctp with ppid fix

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,7 +23,7 @@ func Dial(ctx context.Context, net string, laddr, raddr *sctp.SCTPAddr, cfg *Con
 		mode:        modeClient,
 		stateChan:   make(chan State),
 		established: make(chan struct{}),
-		sctpInfo:    &sctp.SndRcvInfo{PPID: 0x03000000, Stream: 0},
+		sctpInfo:    &sctp.SndRcvInfo{PPID: 0x00000003, Stream: 0},
 		cfg:         cfg,
 	}
 

--- a/client.go
+++ b/client.go
@@ -23,7 +23,7 @@ func Dial(ctx context.Context, net string, laddr, raddr *sctp.SCTPAddr, cfg *Con
 		mode:        modeClient,
 		stateChan:   make(chan State),
 		established: make(chan struct{}),
-		sctpInfo:    &sctp.SndRcvInfo{PPID: 0x00000003, Stream: 0},
+		sctpInfo:    &sctp.SndRcvInfo{PPID: 3, Stream: 0},
 		cfg:         cfg,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.23
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/ishidawataru/sctp v0.0.0-20250427101207-53eab83c1cf6
+	github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2
 	github.com/pascaldekloe/goe v0.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/ishidawataru/sctp v0.0.0-20250427101207-53eab83c1cf6 h1:BcV9jRUmgOhP6dWHo1awB1QQQjGMRUuS9E4/lmwcbQY=
-github.com/ishidawataru/sctp v0.0.0-20250427101207-53eab83c1cf6/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
+github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2 h1:36qep4gxKs+JgeHGWeQ040RyZdt9kQlLglL1rFVn/oQ=
+github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/pascaldekloe/goe v0.1.1 h1:Ah6WQ56rZONR3RW3qWa2NCZ6JAVvSpUcoLBaOmYFt9Q=
 github.com/pascaldekloe/goe v0.1.1/go.mod h1:KSyfaxQOh0HZPjDP1FL/kFtbqYqrALJTaMafFUIccqU=

--- a/server.go
+++ b/server.go
@@ -46,7 +46,7 @@ func (l *Listener) Accept(ctx context.Context) (*Conn, error) {
 		mode:        modeServer,
 		stateChan:   make(chan State),
 		established: make(chan struct{}),
-		sctpInfo:    &sctp.SndRcvInfo{PPID: 0x03000000, Stream: 0},
+		sctpInfo:    &sctp.SndRcvInfo{PPID: 0x00000003, Stream: 0},
 		cfg:         l.Config,
 	}
 

--- a/server.go
+++ b/server.go
@@ -46,7 +46,7 @@ func (l *Listener) Accept(ctx context.Context) (*Conn, error) {
 		mode:        modeServer,
 		stateChan:   make(chan State),
 		established: make(chan struct{}),
-		sctpInfo:    &sctp.SndRcvInfo{PPID: 0x00000003, Stream: 0},
+		sctpInfo:    &sctp.SndRcvInfo{PPID: 3, Stream: 0},
 		cfg:         l.Config,
 	}
 


### PR DESCRIPTION
This PR updates the sctp package to the latest. It also modifies the PPID as per the new required input to the SCTP package.